### PR TITLE
よりシンプルな実装に修正

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,24 +2,74 @@ package jsonrpc
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/rpc"
-	org "net/rpc/jsonrpc"
+	jsonrpcorg "net/rpc/jsonrpc"
 	"net/url"
-	"sync"
 )
 
-var (
-	None = &struct{}{}
-)
+// NewClientLocal ...
+func NewClientLocal() *rpc.Client {
+	cl, cr := net.Pipe()
+	go ServeCodec(jsonrpcorg.NewServerCodec(cl))
+	return jsonrpcorg.NewClient(cr)
+}
 
-// DialHTTP connects
+// NewClientHTTP ...
+func NewClientHTTP(endpoint string) *rpc.Client {
+	buf := bytes.NewBuffer(nil)
+	r, w := io.Pipe()
+	return rpc.NewClientWithCodec(&rpcCodec{
+		ClientCodec: jsonrpcorg.NewClientCodec(struct {
+			io.Writer
+			io.ReadCloser
+		}{buf, r}),
+		endpoint: endpoint,
+		buf:      buf,
+		writer:   w,
+		ch:       make(chan *http.Response, 1),
+	})
+}
+
+type rpcCodec struct {
+	rpc.ClientCodec
+	endpoint string
+	buf      *bytes.Buffer
+	writer   io.Writer
+	ch       chan *http.Response
+}
+
+func (c *rpcCodec) WriteRequest(r *rpc.Request, v interface{}) error {
+	c.buf.Reset()
+	if err := c.ClientCodec.WriteRequest(r, v); err != nil {
+		return err
+	}
+	resp, err := http.Post(c.endpoint, "application/json-rpc", c.buf)
+	if err != nil {
+		return err
+	}
+	c.ch <- resp
+	return nil
+}
+
+func (c *rpcCodec) ReadResponseHeader(r *rpc.Response) error {
+	resp := <-c.ch
+	if resp != nil {
+		go func() {
+			io.Copy(c.writer, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+	return c.ClientCodec.ReadResponseHeader(r)
+}
+
+// DialHTTP connected Client
 func DialHTTP(endpoint string, config *tls.Config) (*rpc.Client, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
@@ -52,7 +102,7 @@ func DialHTTP(endpoint string, config *tls.Config) (*rpc.Client, error) {
 
 	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: "CONNECT"})
 	if err == nil && resp.Status == Connected {
-		return org.NewClient(conn), nil
+		return jsonrpcorg.NewClient(conn), nil
 	}
 	if err == nil {
 		err = errors.New("unexpected HTTP response: " + resp.Status)
@@ -64,132 +114,4 @@ func DialHTTP(endpoint string, config *tls.Config) (*rpc.Client, error) {
 		Addr: nil,
 		Err:  err,
 	}
-}
-
-// Client ...
-type Client struct {
-	sync.RWMutex
-	newFunc func() (*rpc.Client, error)
-	c       *rpc.Client
-	closing bool
-}
-
-// NewClient ...
-func NewClient(endpoint string, config *tls.Config) *Client {
-	client := new(Client)
-	client.newFunc = func() (*rpc.Client, error) {
-		return DialHTTP(endpoint, config)
-	}
-	return client
-}
-
-func (client *Client) conn() (*rpc.Client, error) {
-	client.RLock()
-	c, closing := client.c, client.closing
-	client.RUnlock()
-	if closing {
-		return nil, fmt.Errorf("closed")
-	}
-	if c != nil {
-		return c, nil
-	}
-	client.Lock()
-	defer client.Unlock()
-	c, err := client.newFunc()
-	if err != nil {
-		return nil, err
-	}
-	client.c = c
-	return c, nil
-}
-
-// Go ...
-func (client *Client) Go(serviceMethod string, args interface{}, reply interface{}, done chan *rpc.Call) *rpc.Call {
-	if done == nil {
-		done = make(chan *rpc.Call, 1)
-	} else if cap(done) == 0 {
-		log.Panic("rpc: done channel is unbuffered")
-	}
-	c, err := client.conn()
-	if err != nil {
-		call := &rpc.Call{
-			ServiceMethod: serviceMethod,
-			Args:          args,
-			Reply:         reply,
-			Done:          done,
-			Error:         err,
-		}
-		call.Done <- call
-		return call
-	}
-	pre := make(chan *rpc.Call, 1)
-	call := c.Go(serviceMethod, args, reply, pre)
-	if call.Error != nil {
-		return call
-	}
-	call.Done = done
-	go func() {
-		r, ok := <-pre
-		if !ok {
-			return
-		}
-		if r.Error != nil {
-			if _, ok := r.Error.(rpc.ServerError); ok {
-				client.Lock()
-				client.c.Close()
-				client.c = nil
-				client.Unlock()
-			}
-		}
-		select {
-		case done <- r:
-		default:
-		}
-		client.Lock()
-		if client.closing {
-			client.c.Close()
-			client.c = nil
-		}
-		client.Unlock()
-	}()
-	return call
-}
-
-// Call ...
-func (client *Client) Call(serviceMethod string, args interface{}, reply interface{}) error {
-	call := <-client.Go(serviceMethod, args, reply, make(chan *rpc.Call, 1)).Done
-	return call.Error
-}
-
-// Close ...
-func (client *Client) Close() error {
-	client.Lock()
-	defer client.Unlock()
-	client.closing = true
-	return nil
-}
-
-// Get ...
-func (client *Client) Get(prefix string) Service {
-	return &service{Client: client, prefix: prefix + "."}
-}
-
-// Service ...
-type Service interface {
-	Call(serviceMethod string, args interface{}, reply interface{}) error
-	Go(serviceMethod string, args interface{}, reply interface{}, done chan *rpc.Call) *rpc.Call
-	Close() error
-}
-
-type service struct {
-	*Client
-	prefix string
-}
-
-func (s *service) Call(serviceMethod string, args interface{}, reply interface{}) error {
-	return s.Client.Call(s.prefix+serviceMethod, args, reply)
-}
-
-func (s *service) Go(serviceMethod string, args interface{}, reply interface{}, done chan *rpc.Call) *rpc.Call {
-	return s.Client.Go(s.prefix+serviceMethod, args, reply, done)
 }


### PR DESCRIPTION
#1 
- クライアントのコネクションプールをやめる
- POSTとCONNECT両対応のサーバー実装
- DialHTTPはCONNECTを使うクライアント
- NewClientHTTPはPOSTを使うクライアント
- NewClientLocalはループバック(net.Pipe)でつながるクライアント
- それぞれのテストを追加